### PR TITLE
Do not set parameter on FrozenParameterBag. Fixes #16

### DIFF
--- a/src/CcaDependencyInjectionBundle.php
+++ b/src/CcaDependencyInjectionBundle.php
@@ -36,6 +36,10 @@ class CcaDependencyInjectionBundle extends Bundle
     {
         parent::build($container);
 
+        if ($container->getParameterBag() instanceof FrozenParameterBag) {
+            return;
+        }
+        
         // Add all resource paths to keep them handy.
         $container->setParameter('cca.legacy_dic', $this->getResourcePaths($container));
     }

--- a/src/CcaDependencyInjectionBundle.php
+++ b/src/CcaDependencyInjectionBundle.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dependency-container.
  *
- * (c) 2013-2019 Contao Community Alliance <https://c-c-a.org>
+ * (c) 2013-2020 Contao Community Alliance <https://c-c-a.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,7 +14,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright  2013-2019 Contao Community Alliance <https://c-c-a.org>
+ * @copyright  2013-2020 Contao Community Alliance <https://c-c-a.org>
  * @license    https://github.com/contao-community-alliance/dependency-container/blob/master/LICENSE LGPL-3.0
  * @link       https://github.com/contao-community-alliance/dependency-container
  * @filesource
@@ -22,8 +22,6 @@
 
 namespace DependencyInjection\Container;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -31,89 +29,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class CcaDependencyInjectionBundle extends Bundle
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function build(ContainerBuilder $container)
-    {
-        parent::build($container);
-
-        if ($container->getParameterBag() instanceof FrozenParameterBag) {
-            return;
-        }
-        
-        // Add all resource paths to keep them handy.
-        $container->setParameter('cca.legacy_dic', $this->getResourcePaths($container));
-    }
-
-    /**
-     * Returns the Contao resources paths as array.
-     *
-     * @param ContainerBuilder $container The container builder.
-     *
-     * @return array
-     */
-    private function getResourcePaths(ContainerBuilder $container)
-    {
-        $paths   = [];
-        $rootDir = dirname($container->getParameter('kernel.root_dir'));
-
-        foreach ($container->getParameter('kernel.bundles') as $name => $class) {
-            if (null !== ($path = $this->getResourcePathFromBundle($rootDir, $name, $class))) {
-                $paths[] = $path;
-            }
-        }
-
-        if (is_readable($rootDir . '/app/Resources/contao/config/services.php')) {
-            $paths[] = $rootDir . '/app/Resources/contao/config/services.php';
-        }
-
-        if (is_readable($rootDir . '/system/config/services.php')) {
-            $paths[] = $rootDir . '/system/config/services.php';
-        }
-
-        return $paths;
-    }
-
-    /**
-     * Generate the path from the bundle (if any exists).
-     *
-     * @param string $rootDir The app root dir.
-     * @param string $name    The name of the bundle.
-     * @param string $class   The bundle class name.
-     *
-     * @return string|null
-     */
-    private function getResourcePathFromBundle($rootDir, $name, $class)
-    {
-        if ('Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle' === $class) {
-            $path = sprintf('%s/system/modules/%s', $rootDir, $name);
-        } else {
-            $path = $this->getResourcePathFromClassName($class);
-        }
-
-        if (null !== $path && is_readable($file = $path . '/config/services.php')) {
-            return $file;
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns the resources path from the class name.
-     *
-     * @param string $class The class name of the bundle.
-     *
-     * @return string|null
-     */
-    private function getResourcePathFromClassName($class)
-    {
-        $reflection = new \ReflectionClass($class);
-
-        if (is_dir($dir = dirname($reflection->getFileName()).'/Resources/contao')) {
-            return $dir;
-        }
-
-        return null;
-    }
 }

--- a/src/CcaDependencyInjectionBundle.php
+++ b/src/CcaDependencyInjectionBundle.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dependency-container.
  *
- * (c) 2013-2018 Contao Community Alliance <https://c-c-a.org>
+ * (c) 2013-2019 Contao Community Alliance <https://c-c-a.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    contao-community-alliance/dependency-container
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2018 Contao Community Alliance <https://c-c-a.org>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2013-2019 Contao Community Alliance <https://c-c-a.org>
  * @license    https://github.com/contao-community-alliance/dependency-container/blob/master/LICENSE LGPL-3.0
  * @link       https://github.com/contao-community-alliance/dependency-container
  * @filesource
@@ -22,6 +23,7 @@
 namespace DependencyInjection\Container;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**

--- a/src/DependencyInjection/CcaDependencyInjectionExtension.php
+++ b/src/DependencyInjection/CcaDependencyInjectionExtension.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dependency-container.
  *
- * (c) 2013-2018 Contao Community Alliance <https://c-c-a.org>
+ * (c) 2013-2020 Contao Community Alliance <https://c-c-a.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    contao-community-alliance/dependency-container
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2018 Contao Community Alliance <https://c-c-a.org>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2013-2020 Contao Community Alliance <https://c-c-a.org>
  * @license    https://github.com/contao-community-alliance/dependency-container/blob/master/LICENSE LGPL-3.0
  * @link       https://github.com/contao-community-alliance/dependency-container
  * @filesource
@@ -38,5 +39,79 @@ class CcaDependencyInjectionExtension extends Extension
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
+
+        // Add all resource paths to keep them handy.
+        $container->setParameter('cca.legacy_dic', $this->getResourcePaths($container));
+    }
+
+    /**
+     * Returns the Contao resources paths as array.
+     *
+     * @param ContainerBuilder $container The container builder.
+     *
+     * @return array
+     */
+    private function getResourcePaths(ContainerBuilder $container)
+    {
+        $paths   = [];
+        $rootDir = dirname($container->getParameter('kernel.root_dir'));
+
+        foreach ($container->getParameter('kernel.bundles') as $name => $class) {
+            if (null !== ($path = $this->getResourcePathFromBundle($rootDir, $name, $class))) {
+                $paths[] = $path;
+            }
+        }
+
+        if (is_readable($rootDir . '/app/Resources/contao/config/services.php')) {
+            $paths[] = $rootDir . '/app/Resources/contao/config/services.php';
+        }
+
+        if (is_readable($rootDir . '/system/config/services.php')) {
+            $paths[] = $rootDir . '/system/config/services.php';
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Generate the path from the bundle (if any exists).
+     *
+     * @param string $rootDir The app root dir.
+     * @param string $name    The name of the bundle.
+     * @param string $class   The bundle class name.
+     *
+     * @return string|null
+     */
+    private function getResourcePathFromBundle($rootDir, $name, $class)
+    {
+        if ('Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle' === $class) {
+            $path = sprintf('%s/system/modules/%s', $rootDir, $name);
+        } else {
+            $path = $this->getResourcePathFromClassName($class);
+        }
+
+        if (null !== $path && is_readable($file = $path . '/config/services.php')) {
+            return $file;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the resources path from the class name.
+     *
+     * @param string $class The class name of the bundle.
+     *
+     * @return string|null
+     */
+    private function getResourcePathFromClassName($class)
+    {
+        $reflection = new \ReflectionClass($class);
+
+        if (is_dir($dir = dirname($reflection->getFileName()) . '/Resources/contao')) {
+            return $dir;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Description

Do not set parameter on FrozenParameterBag. Fixes #16
`setParameter()` is unavailable after the container is compiled.

## Checklist
- [ ] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
